### PR TITLE
Broadcast STOMP messages

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -94,7 +94,7 @@ static boost::mutex               initMutex;
 // Stomp client
 #include "BoostStomp.hpp"
 static STOMP::BoostStomp* stomp_client;
-static string*          notifications_topic = new string("/queue/zwave/monitor");
+static string*          notifications_topic = new string("/topic/zwave/monitor");
 
 // JSON body indicator
 static bool jsonMessageBody = false;


### PR DESCRIPTION
I like to allow multiple clients to access the OpenZWave notifications. I can't think of any reason why an application would want to only have a single handler consume each event. This small change makes it so a copy of each event is broadcast to each of the registered listeners.